### PR TITLE
cli.py: Removing -a, --any option from JSON Cut

### DIFF
--- a/jsoncut/cli.py
+++ b/jsoncut/cli.py
@@ -70,8 +70,6 @@ def output(ctx, output, indent, is_json):
         help=('(key, default-value); same as get, except uses a default value'
               'when the key or index is not found'))
 @option('-d', '--del', 'delkeys', help='delete JSON keys and/or indexes')
-@option('-a', '--any', is_flag=True, default=True,
-        help='get/del any matching keys; supress key not found errors.')
 @option('-l', '--list', 'listkeys', is_flag=True,
         help='numbered JSON keys list')
 @option('-i', '--inspect', is_flag=True,

--- a/jsoncut/core.py
+++ b/jsoncut/core.py
@@ -252,7 +252,7 @@ def into_key(*keys, fullpath=False):
     return '.'.join(keys) if fullpath else keys[-1]
 
 
-def get_items(d, *keylists, fullpath=False, any=False, n=0):
+def get_items(d, *keylists, fullpath=False, any=True, n=0):
     """Get multiple nested items from a dict given the keys.
 
     Args:
@@ -287,7 +287,7 @@ def get_items(d, *keylists, fullpath=False, any=False, n=0):
             into = into_key(*keylist, fullpath=fullpath)
             result[into] = select_key(d, *keylist, no_default=True)
         except exc.KeyNotFound as e:
-            if not any:
+            if any:
                 kwds = dict(op='get', itemnum=n, data=d, keylist=keylists)
                 raise exc.KeyNotFound(e, **kwds)
         except exc.IndexOutOfRange as e:

--- a/jsoncut/core.py
+++ b/jsoncut/core.py
@@ -287,7 +287,7 @@ def get_items(d, *keylists, fullpath=False, any=True, n=0):
             into = into_key(*keylist, fullpath=fullpath)
             result[into] = select_key(d, *keylist, no_default=True)
         except exc.KeyNotFound as e:
-            if any:
+            if not any:
                 kwds = dict(op='get', itemnum=n, data=d, keylist=keylists)
                 raise exc.KeyNotFound(e, **kwds)
         except exc.IndexOutOfRange as e:


### PR DESCRIPTION
cli.py: delete "-a","-any" options
core.py: Modifying the function so that the value
         of "any" parameter is always true. Also,
         update the if since the functionality
         changed after we change the parameter.