### PR TITLE
Replace 'indent' with 'compact' in kwds array

### DIFF
--- a/jsoncut/cli.py
+++ b/jsoncut/cli.py
@@ -88,7 +88,7 @@ def main(ctx, **kwds):
     results = cut(data, kwds)
     if results:
         is_json = not (kwds['listkeys'] or kwds['inspect'] or kwds['count'])
-        output(ctx, results, kwds['indent'], is_json)
+        output(ctx, results, kwds['compact'], is_json)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes #20

The indent option was changed to compact but it was still used as
a parameter to the output function, causing a keyerror.