### PR TITLE
Add expand option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,7 @@ JSON Cut By Example
                                     through that array; this option disables
                                     iteratation so that the root-level array
                                     can be sliced.
+    -e, --expand                    Expand key numbers to key names.
     --version                       Show the version and exit.
     --help                          Show this message and exit.
 

--- a/jsoncut/cli.py
+++ b/jsoncut/cli.py
@@ -66,19 +66,21 @@ def output(ctx, output, compact, is_json):
 @option('-G', '--getdefault', 'getdefaults', type=(str, str), multiple=True,
         help=('(key, default-value); same as get, except uses a default value'
               'when the key or index is not found'))
-@option('-d', '--del', 'delkeys', multiple=True, help='delete JSON keys and/or indexes')
+@option('-d', '--del', 'delkeys', multiple=True, help='Delete JSON keys and/or indexes')
 @option('-l', '--list', 'listkeys', is_flag=True,
-        help='numbered JSON keys list')
+        help='Numbered JSON keys list')
 @option('-i', '--inspect', is_flag=True,
-        help='inspect JSON document; all keys, indexes & types')
+        help='Inspect JSON document; all keys, indexes & types')
 @option('-c', '--count', is_flag=True,
-        help='count elements in top-level JSON arrays')
-@option('-f', '--fullscan', is_flag=True, help='deep inpections')
-@option('-p', '--fullpath', is_flag=True, help='preserve full path for names')
-@option('-q', '--quotechar', default='"', help='set quoting char for keys')
+        help='Count elements in top-level JSON arrays')
+@option('-f', '--fullscan', is_flag=True, help='Deep inspections')
+@option('-p', '--fullpath', is_flag=True, help='Preserve full path for names')
+@option('-q', '--quotechar', default='"', help='Set quoting char for keys')
 @option('-C', '--compact', default=False, help='Compacts the JSON output')
-@option('-n', '--nocolor', is_flag=True, help='disable syntax highlighting')
-@option('-s', '--slice', 'slice_', is_flag=True, help='disable sequencer')
+@option('-n', '--nocolor', is_flag=True, help='Disable syntax highlighting')
+@option('-s', '--slice', 'slice_', is_flag=True, help='Disable sequencer')
+@option('-e', '--expand', is_flag=True,
+        help='Expand key numbers to key names')
 @version_option(version='0.6', prog_name='JSON Cut')
 @click.pass_context
 def main(ctx, **kwds):

--- a/jsoncut/core.py
+++ b/jsoncut/core.py
@@ -469,7 +469,7 @@ def cut(data, rootkey=None, getkeys=None, getdefaults=None, delkeys=None,
             specified comma-separated key numbers as second argument
         fullpath (bool): used with get*; include the full key name path.
         fullscan (bool): don't skip previously visited JSON Keys.
-        quotechar (str): the quote charcter used around JSON Keys.
+        quotechar (str): the quote character used around JSON Keys.
         slice (bool): when the document root is an array don't iterate
     """
     if rootkey:

--- a/jsoncut/exceptions.py
+++ b/jsoncut/exceptions.py
@@ -73,6 +73,10 @@ class KeyNumberOutOfRange(JsonCutError, ValueError):
 
     pass
 
+class KeyNotNumeric(JsonCutError, ValueError):
+    """Invalid Non-Numeric Key Type."""
+
+    pass
 
 class KeyTypeError(JsonCutError, TypeError):
     """Attempt to use an index on a Mapping or a key on a Sequence."""
@@ -125,7 +129,7 @@ class IndexOutOfRange(JsonCutError, IndexError):
         """Initialize IndexOutOfRange Exception.
 
         Args:
-            exc (Exception): orignial TypeError excecption.
+            exc (Exception): original TypeError exception.
             op (str): name of operation where the exception occured.
             key (str): the key being operated on.
             itemnum (int): the data item number; if data is a Sequence.


### PR DESCRIPTION
Fixes #16 

Add the expand (-e) option that will allow the user to print the long
version of the a given command with any key numbers replaced with
their respective key names.