### PR TITLE
Update readme and fix syntax coloring issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,9 +58,11 @@ JSON Cut By Example
                                     rather than the default single-quotes;
                                     elimates having to escape quote
                                     characters around keynames.
+    -c, --count                     Count elements in top-level JSON arrays.
+    -q, --quotechar                 Set quoting char for keys.
     -C, --compact                   Compacts the JSON output; the default
                                     value is False
-    -c, --nocolor                   Disable syntax highlighting.
+    -n, --nocolor                   Disable syntax highlighting.
     -s, --slice                     Used when the root of the JSON document
                                     is an array; the default is to iterate
                                     through that array; this option disables

--- a/jsoncut/highlighter.py
+++ b/jsoncut/highlighter.py
@@ -27,16 +27,6 @@ try:
 except ImportError:
     pass
 
-STYLE = dict(Token='darkgray', Keyword='brown', Name_Tag='darkgreen',
-             String='lightgray', Number='fuchsia')
-
-
-def get_style(style=STYLE):
-    """Load Pygments custom style."""
-    def getattrs(obj, names):
-        return reduce(getattr, names.split('_'), obj)
-    return {getattrs(pygments.token, k): (v,) * 2 for k, v in style.items()}
-
 
 def format_json(d, compact=False, indent=2):
     """Format JSON; compact or indented."""
@@ -44,10 +34,10 @@ def format_json(d, compact=False, indent=2):
     return json.dumps(d, indent=indent, separators=separators)
 
 
-def highlight_json(d, style=STYLE):
+def highlight_json(d):
     """JSON Syntax highlighter."""
     try:
-        formatter = TerminalFormatter(colorscheme=get_style(style))
+        formatter = TerminalFormatter()
     except (NameError, AttributeError):
         return d
     return pygments.highlight(d, JsonLexer(), formatter)


### PR DESCRIPTION
Update main readme to match actual cli options as the --nocolor was listed to use the -c options which corresponds to the --count option. This gave confusing results.

It looks like the color names used by pygments have changed, so instead of setting them explicitly let TerminalFormatter use the default colorscheme.